### PR TITLE
Fix Builder#inspect to work with middleware classes

### DIFF
--- a/lib/middleware/builder.rb
+++ b/lib/middleware/builder.rb
@@ -131,7 +131,9 @@ module Middleware
 
     def inspect
       '[' + stack.reduce([]) do |carry, middleware|
-        carry << "#{middleware[0].class.name}(#{middleware[1].join(', ')})"
+        name = middleware[0].is_a?(Proc) ? 'Proc' : middleware[0].name
+
+        carry << "#{name}(#{middleware[1].join(', ')})"
       end.join(', ') + ']'
     end
 

--- a/spec/middleware/builder_spec.rb
+++ b/spec/middleware/builder_spec.rb
@@ -199,10 +199,22 @@ describe Middleware::Builder do
   end
 
   context 'debugging' do
+    class Echo
+      def initialize(app, message)
+        @app = app
+        @message = message
+      end
+
+      def call(env)
+        @app.call(env)
+      end
+    end
+
     it 'has an inspect method' do
       instance.use appender_proc(1)
       instance.use appender_proc(1), 2
-      expect(instance.inspect).to eq '[Proc(), Proc(2)]'
+      instance.use Echo, 'Hi, how are you?'
+      expect(instance.inspect).to eq '[Proc(), Proc(2), Echo(Hi, how are you?)]'
     end
   end
 end


### PR DESCRIPTION
Given the following stack:

```ruby
Middleware::Builder.new { |b|
  b.use ->(env, msg) { puts msg }, 'some message'
  b.use Echo, "Hello, World!"
}.inspect 
```

Before:
```ruby
#=> [Proc(some message), Class(Hello, World)]
```

After:

```ruby
#=> [Proc(some message), Echo(Hello, World)]
```