### PR TITLE
Fix ruby 3 error when keyword argument is passed

### DIFF
--- a/lib/middleware/builder.rb
+++ b/lib/middleware/builder.rb
@@ -73,12 +73,12 @@ module Middleware
     # of the middleware.
     #
     # @param [Class] middleware The middleware class
-    def use(middleware, *args, &block)
+    def use(middleware, *args, **kwargs, &block)
       if middleware.is_a?(Builder)
         # Merge in the other builder's stack into our own
         stack.concat(middleware.stack)
       else
-        stack << [middleware, args, block]
+        stack << [middleware, args, kwargs, block]
       end
 
       self

--- a/lib/middleware/runner.rb
+++ b/lib/middleware/runner.rb
@@ -42,17 +42,18 @@ module Middleware
       # is always the empty middleware, which does nothing but return.
       stack.reverse.inject(EMPTY_MIDDLEWARE) do |next_middleware, current_middleware|
         # Unpack the actual item
-        klass, args, block = current_middleware
+        klass, args, kwargs, block = current_middleware
 
         # Default the arguments to an empty array. Otherwise in Ruby 1.8
         # a `nil` args will actually pass `nil` into the class. Not what
         # we want!
         args ||= []
+        kwargs ||= {}
 
         if klass.is_a?(Class)
           # If the klass actually is a class, then instantiate it with
           # the app and any other arguments given.
-          klass.new(next_middleware, *args, &block)
+          klass.new(next_middleware, *args, **kwargs, &block)
         elsif klass.respond_to?(:call)
           # Make it a lambda which calls the item then forwards up
           # the chain.

--- a/spec/middleware/builder_spec.rb
+++ b/spec/middleware/builder_spec.rb
@@ -4,6 +4,20 @@ describe Middleware::Builder do
   let(:data) { { data: [] } }
   let(:instance) { described_class.new }
 
+  class Foo
+    def initialize app, pos, key:
+      @app = app
+      @pos = pos
+      @key = key
+    end
+
+    def call env
+      env[:pos] = @pos
+      env[:key] = @key
+      @app.call(env)
+    end
+  end
+
   # This returns a proc that can be used with the builder
   # that simply appends data to an array in the env.
   def appender_proc(data)
@@ -51,6 +65,16 @@ describe Middleware::Builder do
       instance.call(data)
 
       expect(data[:data]).to eq true
+    end
+
+    it 'handles positional and keyword arguments' do
+      data = {}
+
+      instance.use Foo, 1, key: 2
+      instance.call(data)
+
+      expect(data[:pos]).to eq 1
+      expect(data[:key]).to eq 2
     end
 
     it 'is able to add multiple items' do

--- a/spec/middleware/runner_spec.rb
+++ b/spec/middleware/runner_spec.rb
@@ -85,6 +85,27 @@ describe Middleware::Runner do
     expect(env[:result]).to eq 42
   end
 
+  it 'passes in keyword arguments if given' do
+    a = Class.new do
+      def initialize(_app, foo = nil, bar: nil)
+        @foo = foo
+        @bar = bar
+      end
+
+      def call(env)
+        env[:foo] = @foo
+        env[:bar] = @bar
+      end
+    end
+
+    env = {}
+    instance = described_class.new([[a, [42], { bar: 1764 }, nil]])
+    instance.call(env)
+
+    expect(env[:foo]).to eq 42
+    expect(env[:bar]).to eq 1764
+  end
+
   it 'passes in a block if given' do
     a = Class.new do
       def initialize(_app, &block)
@@ -98,7 +119,7 @@ describe Middleware::Runner do
 
     block = proc { 42 }
     env = {}
-    instance = described_class.new([[a, nil, block]])
+    instance = described_class.new([[a, [], {}, block]])
     instance.call(env)
 
     expect(env[:result]).to eq 42


### PR DESCRIPTION
In Ruby 3, keyword arguments must be splat separately (using double splat):

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This would mean the gem will no longer be compatible to Ruby < 2.0